### PR TITLE
Roman Numeral to Integer

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,14 +1,14 @@
 {
   "configurations": [
     {
-      "name": "macos-clang-arm64",
+      "name": "windows-clang-x64",
       "includePath": [
         "${workspaceFolder}/**"
       ],
-      "compilerPath": "/usr/bin/clang",
+      "compilerPath": "clang",
       "cStandard": "${default}",
       "cppStandard": "${default}",
-      "intelliSenseMode": "macos-clang-arm64",
+      "intelliSenseMode": "windows-clang-x64",
       "compilerArgs": [
         ""
       ]

--- a/Python/RomanNumeraltoInteger.py
+++ b/Python/RomanNumeraltoInteger.py
@@ -1,0 +1,22 @@
+def roman_to_int(s):
+    """
+    Converts a Roman numeral to an integer.
+
+    :param s: A string representing a Roman numeral.
+    :return: An integer equivalent of the Roman numeral.
+    """
+    roman = {'I': 1, 'V': 5, 'X': 10, 'L': 50, 'C': 100, 'D': 500, 'M': 1000}
+    total = 0
+    prev_value = 0
+    
+    for char in s:
+        current_value = roman[char]
+        total += current_value
+        if current_value > prev_value:
+            total -= 2 * prev_value
+        prev_value = current_value
+    
+    return total
+
+# Example usage:
+print(roman_to_int("MCMXCIV"))  # Output: 1994


### PR DESCRIPTION
This Python function converts a Roman numeral string into its integer equivalent. Roman numerals use seven symbols, each with specific values:

I = 1
V = 5
X = 10
L = 50
C = 100
D = 500
M = 1000
When a smaller numeral appears before a larger one (like in IV for 4 or IX for 9), the smaller numeral is subtracted from the larger one. Otherwise, the values are simply added together.

Algorithm:
Initialize total sum: Start with a total of 0.
Iterate through each character of the Roman numeral string:
Add the value of the current character (numeral) to the total.
If the current numeral is larger than the previous one, subtract twice the value of the previous numeral to account for the subtraction rule in Roman numerals.
Return the total sum: After processing all characters, the result is the integer equivalent of the Roman numeral.
